### PR TITLE
Fix TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,9 +11,8 @@ declare module "react-native-actions-sheet" {
     indicatorColor?: string;
     overlayColor?: string;
     closeAnimationDuration?:number;
-    defaultOverlayOpacity?:number;
     openAnimationDuration?:number;
-    bounciness:number;
+    bounciness?:number;
     closeOnPressBack?: boolean;
     defaultOverlayOpacity:number;
     gestureEnabled?: boolean;


### PR DESCRIPTION
- Removed duplicate `defaultOverlayOpacity` property
- Made `bounciness` prop optional