### PR TITLE
Optional `defaultOverlayOpacity` prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ declare module "react-native-actions-sheet" {
     openAnimationDuration?:number;
     bounciness?:number;
     closeOnPressBack?: boolean;
-    defaultOverlayOpacity:number;
+    defaultOverlayOpacity?:number;
     gestureEnabled?: boolean;
     bounceOnOpen?: boolean;
     onClose?: () => void;


### PR DESCRIPTION
`defaultOverlayOpacity` has a default value and is marked as optional in the README, but the corresponding entry in the type definition makes it mandatory.