### PR TITLE
Fix "Can't find variable: extraScroll" in 0.1.8

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ export default class ActionSheet extends Component {
   };
 
   _onScrollEndDrag = event => {
-    let {springOffset} = this.props;
+    let {springOffset, extraScroll} = this.props;
 
     let verticalOffset = event.nativeEvent.contentOffset.y;
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4425455/73320349-f83cdb00-420c-11ea-8571-697280375e6c.png)


To repro:

- Bump the `react-native-action-sheet` version to the latest in the example
- Run `yarn install`
- Run the app
- Open the action sheet
- Press the action sheet and drag up