### PR TITLE
Add ability to explicitly show/hide modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-actions-sheet",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A Cross Platform(Android & iOS) ActionSheet with a robust and flexible api, native performance and zero dependency code for react native. Create anything you want inside ActionSheet.",
   "main": "index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -64,9 +64,16 @@ export default class ActionSheet extends Component {
    * Open/Close the ActionSheet
    */
 
-  setModalVisible = () => {
+  setModalVisible = (visible) => {
     deviceHeight = Dimensions.get("window").height;
-    if (!this.state.modalVisible) {
+    let modalVisible = this.state.modalVisible;
+    if (visible !== undefined) {
+      if (modalVisible === visible) {
+        return;
+      }
+      modalVisible = !visible;
+    }
+    if (!modalVisible) {
       this.setState({
         modalVisible: true,
         scrollable: this.props.gestureEnabled,


### PR DESCRIPTION
For better control of when to show or hide modal, a `visible` argument is proposed for the `setModalVisible` method. 