### PR TITLE
Add the ability to allow the bottom sheet to be closable or not

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -263,6 +263,28 @@ Default: `false`
     bounceOnOpen?: boolean;
 
     /**
+     * Indicates if the bottom-sheet can be closed.
+
+| Type | Required |
+| ---- | -------- |
+| boolean | no |
+
+Default: `true`
+     */
+    closable?: boolean;
+
+    /**
+     * When the closable flag is set to false, this value is used to determine how far from the bottom of the screen the bottom sheet should appear.
+
+| Type | Required |
+| ---- | -------- |
+| number | no |
+
+Default: `200`
+     */
+    bottomOffset?: number;
+
+    /**
      * 
 Event called when the ActionSheet closes.
 
@@ -289,6 +311,6 @@ Event called when the ActionSheet closes.
     /**
      * ActionSheet can be opened or closed using its ref.
      */
-    setModalVisible(visible?:boolean): void;
+    setModalVisible(visible?: boolean): void;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,16 @@
-import React, { Component, createRef } from "react";
 import {
-  View,
-  TouchableOpacity,
-  Dimensions,
-  ScrollView,
-  Modal,
-  KeyboardAvoidingView,
-  Platform,
   Animated,
   DeviceEventEmitter,
+  Dimensions,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  ScrollView,
+  TouchableOpacity,
+  View,
 } from "react-native";
+import React, { Component, createRef } from "react";
+
 import PropTypes from "prop-types";
 import { styles } from "./styles";
 
@@ -94,12 +95,12 @@ export default class ActionSheet extends Component {
 
     Animated.parallel([
       Animated.timing(this.opacityValue, {
-        toValue: 0,
+        toValue: this.props.closable ? 0 : 1,
         duration: animated ? closeAnimationDuration : 1,
         useNativeDriver: true,
       }),
       Animated.timing(this.transformValue, {
-        toValue: this.customComponentHeight * 2,
+        toValue: this.closable ? this.customComponentHeight * 2 : 0,
         duration: animated ? closeAnimationDuration : 1,
         useNativeDriver: true,
       }),
@@ -107,12 +108,14 @@ export default class ActionSheet extends Component {
     this.waitAsync(closeAnimationDuration / 2).then(() => {
       this.scrollViewRef.current?.scrollTo({
         x: 0,
-        y: 0,
-        animated: false,
+        y: this.props.closable ? 0 : (this.customComponentHeight * this.props.initialOffsetFromBottom +
+          deviceHeight * 0.1 +
+          this.props.extraScroll) - this.props.bottomOffset,
+        animated: true,
       });
       this.setState(
         {
-          modalVisible: false,
+          modalVisible: !this.props.closable,
         },
         () => {
           this.layoutHasCalled = false;
@@ -169,8 +172,8 @@ export default class ActionSheet extends Component {
 
       let scrollOffset = gestureEnabled
         ? this.customComponentHeight * initialOffsetFromBottom +
-          addFactor +
-          extraScroll
+        addFactor +
+        extraScroll
         : this.customComponentHeight + addFactor + extraScroll;
 
       if (Platform.OS === "ios") {
@@ -425,13 +428,13 @@ export default class ActionSheet extends Component {
                   CustomHeaderComponent ? (
                     CustomHeaderComponent
                   ) : (
-                    <View
-                      style={[
-                        styles.indicator,
-                        { backgroundColor: indicatorColor },
-                      ]}
-                    />
-                  )
+                      <View
+                        style={[
+                          styles.indicator,
+                          { backgroundColor: indicatorColor },
+                        ]}
+                      />
+                    )
                 ) : null}
 
                 {children}
@@ -484,8 +487,10 @@ ActionSheet.defaultProps = {
   defaultOverlayOpacity: 0.3,
   overlayColor: "black",
   closeOnTouchBackdrop: true,
-  onClose: () => {},
-  onOpen: () => {},
+  closable: true,
+  bottomOffset: 200,
+  onClose: () => { },
+  onOpen: () => { },
 };
 ActionSheet.propTypes = {
   children: PropTypes.node,

--- a/src/styles.js
+++ b/src/styles.js
@@ -1,4 +1,4 @@
-import {StyleSheet} from 'react-native';
+import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
   scrollView: {
@@ -11,7 +11,7 @@ export const styles = StyleSheet.create({
     backgroundColor: 'white',
     borderTopRightRadius: 10,
     borderTopLeftRadius: 10,
-    alignSelf:'center'
+    alignSelf: 'center'
   },
   indicator: {
     height: 6,


### PR DESCRIPTION
Hey guys! For a project I am working on, I wanted to allow the bottom sheet modal to not be 'closable'. This PR adds the ability for the modal to be stay open even if swiped away. Instead, it will bounce to a position defined in a property called 'bottomOffset' which is used to determine how far from the bottom the modal should appear.

`closable` - `boolean` - Default is true (maintains current behaviour)
`bottomOffset` - `number` - Default is 200 and set when `closable` is set to false