### PR TITLE
feat(ActionSheet): new prop to allow keyboard to stay open on press when desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,20 @@ Default: `0`
 
 
 
+#### `keyboardShouldPersistTaps`
+
+Setting the keyboard persistence of the `ScrollView` component.  Should be one of "never", "always" or "handled"
+
+| Type    | Required |
+| ------- | -------- |
+| string | no       |
+
+Default: `never`
+
+#
+
+
+
 #### `closeOnPressBack`
 
 Will the ActionSheet close on `hardwareBackPress` event.

--- a/index.d.ts
+++ b/index.d.ts
@@ -263,6 +263,17 @@ Default: `false`
     bounceOnOpen?: boolean;
 
     /**
+     * Setting the keyboard persistance of the ScrollView component, should be one of "never", "always", or "handled"
+
+| Type | Required |
+| ---- | -------- |
+| string | no |
+
+Default: `"never"`
+     */
+    keyboardShouldPersistTaps?: string;
+
+    /**
      * Prevent ActionSheet from closing on 
      * gesture or tapping on backdrop. 
      * Instead snap it to `bottomOffset` location

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-actions-sheet",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "A Cross Platform(Android & iOS) ActionSheet with a robust and flexible api, native performance and zero dependency code for react native. Create anything you want inside ActionSheet.",
   "main": "index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -373,6 +373,7 @@ export default class ActionSheet extends Component {
       CustomHeaderComponent,
       CustomFooterComponent,
       headerAlwaysVisible,
+      keyboardShouldPersistTaps,
     } = this.props;
 
     return (
@@ -401,6 +402,7 @@ export default class ActionSheet extends Component {
           >
             <ScrollView
               bounces={false}
+              keyboardShouldPersistTaps={keyboardShouldPersistTaps}
               ref={this.scrollViewRef}
               scrollEventThrottle={1}
               showsVerticalScrollIndicator={false}
@@ -530,6 +532,7 @@ ActionSheet.defaultProps = {
   closeOnTouchBackdrop: true,
   onClose: () => {},
   onOpen: () => {},
+  keyboardShouldPersistTaps: "never",
 };
 ActionSheet.propTypes = {
   children: PropTypes.node,
@@ -561,4 +564,5 @@ ActionSheet.propTypes = {
   overlayColor: PropTypes.string,
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
+  keyboardShouldPersistTaps: PropTypes.oneOf([ "always", "default", "never" ]),
 };


### PR DESCRIPTION
Ran into a small issue using an input inside of the action sheet with something like a save button - after typing in the input the keyboard would disappear but not let my press carry through to the button - instead it simply closed the keyboard.  

To the best of my knowledge this is due to the ScrollView and the way it handles taps normally, but adding `keyboardWillPersistTaps` to the ScrollView allowed it to operate as expected for the user.

Instead of forcing it on all the time I created a new prop that would accept the same options `keyboardWillPersistTaps` does and allow the consumer to decide if they want it or not.  Should allow for maximum backwards compatibility and the flexibility to control the keyboard in any way I desire as a consumer.

I was a little unsure of the best prop name to use here, this one is a little verbose, but hopefully clear.  I can change or update this as desired

|  Without keyboardWillPersistTaps | With keyboardWillPersistTaps  |
|---|---|
|  ![2020-05-21 16 25 58](https://user-images.githubusercontent.com/13542564/82608238-e72f2580-9b7f-11ea-8dc0-3c222a4e07a2.gif) | ![2020-05-21 16 26 19](https://user-images.githubusercontent.com/13542564/82608361-1e053b80-9b80-11ea-9d1a-845ba97ba033.gif)  |

