### PR TITLE
Use translucent status bar on Android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -384,6 +384,7 @@ export default class ActionSheet extends Component {
         onShow={() => onOpen}
         onRequestClose={this._onRequestClose}
         transparent={true}
+        statusBarTranslucent={true}
       >
         <Animated.View
           style={[


### PR DESCRIPTION
React Native just added the statusBarTranslucent option to their modal to help the background more seamlessly blend with the status bar.

**Before**
![image](https://user-images.githubusercontent.com/5132904/83313471-20dcdd80-a1cb-11ea-89b2-99289cbdeac8.png)
**After**
![image](https://user-images.githubusercontent.com/5132904/83313453-13275800-a1cb-11ea-8c18-86d1ced3e2f3.png)
