### PR TITLE
 Fix crash problem that occurs if the focused input is not children of current view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-actions-sheet",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A Cross Platform(Android & iOS) ActionSheet with a robust and flexible api, native performance and zero dependency code for react native. Create anything you want inside ActionSheet.",
   "main": "index.js",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,8 @@ import {
   Keyboard,
   TextInput,
   UIManager,
-  StatusBar
+  StatusBar,
+  findNodeHandle
 } from "react-native";
 import { styles } from "./styles";
 
@@ -389,8 +390,12 @@ export default class ActionSheet extends Component {
       const { height: windowHeight } = Dimensions.get("window");
 
       const currentlyFocusedField = TextInput.State.currentlyFocusedInput
-        ? TextInput.State.currentlyFocusedInput()._nativeTag
+        ? findNodeHandle(TextInput.State.currentlyFocusedInput())
         : TextInput.State.currentlyFocusedField();
+
+      if (!currentlyFocusedField) {
+        return;
+      }
 
       UIManager.measure(
         currentlyFocusedField,


### PR DESCRIPTION
In some cases, the previous screen that contains an action sheet may not be unmounted. In this case, if the current screen has an Input and if the user has focused the input, then the application crashes. Because the action sheet in the previous screen still listening to the keyboard event. This pull request fixes this problem.