### PR TITLE
Fix keyboardShouldPersistTaps PropType

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -789,6 +789,6 @@ ActionSheet.propTypes = {
   overlayColor: PropTypes.string,
   onClose: PropTypes.func,
   onOpen: PropTypes.func,
-  keyboardShouldPersistTaps: PropTypes.oneOf(["always", "default", "never"]),
+  keyboardShouldPersistTaps: PropTypes.oneOf(["always", "handled", "never"]),
   statusBarTranslucent: PropTypes.bool,
 };


### PR DESCRIPTION
Hello,
I noticed that the current PropType value for `keyboardShouldPersistTaps` does not match the RN docs.

currently, [keyboardShouldPersistTaps PropType](https://github.com/ammarahm-ed/react-native-actions-sheet/blob/9ec11bf/src/index.js#L792) is defined as:
```javascript
PropTypes.oneOf(["always", "default", "never"])
```

It does not match [official doc for ScrollView](https://reactnative.dev/docs/0.63/scrollview#keyboardshouldpersisttaps):
```javascript
enum('always', 'never', 'handled', false, true) // deprecation warning for `false` & `true`
```

This PR sets PropType to:
```javascript
PropTypes.oneOf(["always", "handled", "never"])
```