### PR TITLE
Fix bug on android

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,7 @@ export default class ActionSheet extends Component {
     this._hideAnimation();
   };
 
-  measure = (async = () => {
+  measure = async () => {
     return new Promise((resolve, reject) => {
       setTimeout(() => {
         UIManager.measureInWindow(
@@ -190,14 +190,11 @@ export default class ActionSheet extends Component {
         );
       }, 50);
     });
-  });
+  };
 
   _showModal = async (event) => {
-    let {
-      gestureEnabled,
-      delayActionSheetDraw,
-      delayActionSheetDrawTime,
-    } = this.props;
+    let { gestureEnabled, delayActionSheetDraw, delayActionSheetDrawTime } =
+      this.props;
     if (!event?.nativeEvent) return;
 
     let height = event.nativeEvent.layout.height;


### PR DESCRIPTION
Thanks for a good component.
I use this library on iOS and Android.
It works well on iOS but The below error occurred on Android.
[Can't find variable 'async']
So i find the 'async' words and edit the 'mesure' function.
As a result, it works well on iOS and Android.
Was it a typo mistake? Anyway, Thanks :)

(PS)
'_showModal' function, i didn't edit that code. It is already edited when i forked.