### PR TITLE
Add missing export of ActionSheetProps

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -1,3 +1,6 @@
 import ActionSheet from "./src/index";
+import { ActionSheetProps as Props } from './src/types'
+
+export type ActionSheetProps = Props
 
 export default ActionSheet;


### PR DESCRIPTION
In my project I have an ActionSheetProvider which makes it easy for us to open an action sheet from everywhere. This works really good for us 💪
However when upgrading to the latest version I've noticed that the ActionSheetProps was no longere exported.

solves #131 