### PR TITLE
Enable control of keyboard padding

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,7 +64,8 @@ const defaultProps = {
   drawUnderStatusBar: false,
   statusBarTranslucent: true,
   gestureEnabled: false,
-  keyboardDismissMode: "none"
+  keyboardDismissMode: "none",
+  keyboardHandlerEnabled: true
 };
 
 type Props = Partial<typeof defaultProps> & ActionSheetProps;
@@ -520,16 +521,17 @@ export default class ActionSheet extends Component<Props, State, any> {
   }
 
   _onKeyboardShow = (event: KeyboardEvent) => {
-    this.isRecoiling = true;
-    let correction = Platform.OS === "android" ? 20 : 5;
-    this.setState({
+    if(this.props.keyboardHandlerEnabled) {
+      this.isRecoiling = true;
+      let correction = Platform.OS === "android" ? 20 : 5;
+      this.setState({
       keyboard: true,
       keyboardPadding: event.endCoordinates.height + correction
-    });
-    console.log(event.endCoordinates.height + correction);
-    waitAsync(300).then(() => {
-      this.isRecoiling = false;
-    });
+      });
+      waitAsync(300).then(() => {
+        this.isRecoiling = false;
+      });
+    }
   };
 
   _onKeyboardHide = () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -304,6 +304,19 @@ export type ActionSheetProps = {
        */
 
      bottomOffset?: number;
+    
+       /**
+     * Allow to choose will content change position when keyboard is visible. 
+     * This is enabled by default.
+     * 
+     * 
+      * | Type | Required |
+ | ---- | -------- |
+ | boolean | no |
+ Default: `true`
+      */
+ 
+     keyboardHandlerEnabled?: boolean;
 
      /**
       * Test ID for unit testing


### PR DESCRIPTION
Hello,
Here is PR that gives some control at least do we want when the keyboard is shown to have padding or not. If we have just one option what is the current case, we are very limited as some designs ( that we already faced ) do not need adjusting content when the keyboard is shown. It would be great if you can accept this prop addition so that we as consumers have more control.