### PR TITLE
Fix opening sheet inside modal

### DIFF
--- a/src/hooks/use-scroll-handlers.ts
+++ b/src/hooks/use-scroll-handlers.ts
@@ -17,7 +17,7 @@ import {ActionSheetRef} from '../index';
  * @param ref ref of the ActionSheet in which the ScrollView is present.
  * @returns
  */
-function useScrollHandlers<T>(id: string, ref: RefObject<ActionSheetRef>) {
+export function useScrollHandlers<T>(id: string, ref: RefObject<ActionSheetRef>) {
   //const [enabled,setEnabled] = useState(false);
   const scrollRef = useRef<T>(null);
   const scrollLayout = useRef<LayoutRectangle>();
@@ -100,5 +100,3 @@ function useScrollHandlers<T>(id: string, ref: RefObject<ActionSheetRef>) {
     scrollEventThrottle: 50,
   };
 }
-
-export default useScrollHandlers;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -781,7 +781,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
           ? StatusBar.currentHeight && StatusBar.currentHeight > 35
             ? 35
             : StatusBar.currentHeight
-          : safeAreaPaddingTop.current > 30
+          : (safeAreaPaddingTop.current || 0) > 30
           ? 30
           : safeAreaPaddingTop.current;
 
@@ -819,7 +819,6 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
             pointerEvents="none"
             collapsable={false}
             onLayout={event => {
-              // safe rea height is 0 inside a modal
               let height = event.nativeEvent.layout.height;
               if (height !== undefined) {
                 actionSheetEventManager.publish('safeAreaLayout');
@@ -865,7 +864,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
                   style={{
                     height:
                       Dimensions.get('window').height + 100 ||
-                      dimensions.height + safeAreaPaddingTop.current + 100,
+                      dimensions.height + (safeAreaPaddingTop.current || 0) + 100,
                     width: '100%',
                     position: 'absolute',
                     zIndex: 2,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -114,7 +114,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
         : snapPoints;
     const initialValue = useRef(-1);
     const actionSheetHeight = useRef(0);
-    const safeAreaPaddingTop = useRef(0);
+    const safeAreaPaddingTop = useRef<number>();
     const contextRef = useRef('global');
     const currentSnapIndex = useRef(initialSnapIndex);
     const minTranslateValue = useRef(0);
@@ -347,7 +347,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
           },
         );
 
-        if (safeAreaPaddingTop.current !== 0 || Platform.OS !== 'ios') {
+        if (safeAreaPaddingTop.current !== undefined || Platform.OS !== 'ios') {
           actionSheetEventManager.publish('safeAreaLayout');
         }
       },
@@ -819,8 +819,9 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
             pointerEvents="none"
             collapsable={false}
             onLayout={event => {
+              // safe rea height is 0 inside a modal
               let height = event.nativeEvent.layout.height;
-              if (height) {
+              if (height !== undefined) {
                 actionSheetEventManager.publish('safeAreaLayout');
                 safeAreaPaddingTop.current = event.nativeEvent.layout.height;
               }

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -50,7 +50,7 @@ registerSheet('local-sheet', LocalSheet,'local-context');
 ``` 
  * @returns 
  */
-function SheetProvider({
+export function SheetProvider({
   context = 'global',
   children,
 }: {
@@ -137,5 +137,3 @@ const RenderSheet = ({id, context}: {id: string; context: string}) => {
 
   return !visible ? null : <Sheet sheetId={id} payload={payload} />;
 };
-
-export default SheetProvider;


### PR DESCRIPTION
This PR closes #201. The problem was that inside a modal, the safe area height is 0 and we were assuming that a 0 height meant that the size of the safe area wasn't still computed. With these changes, the safe area ref starts as undefined until we get the right size.