### PR TITLE
Make data optional in hide() to fix ts error

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -43,7 +43,7 @@ export type ActionSheetRef = {
   /**
    * Hide the ActionSheet.
    */
-  hide: (data: any) => void;
+  hide: (data?: any) => void;
   /**
    * @removed Use `show` or `hide` functions or SheetManager to open/close ActionSheet.
    */


### PR DESCRIPTION
Currently typescript gives this error if we call just `actionSheetRef.current?.hide()`:
```
Expected 1 arguments, but got 0.
```
Making `data` optional should fix it.