### PR TITLE
Fix padding undefined

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -804,7 +804,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
 
       if (!props.useBottomSafeAreaPadding && props.containerStyle) {
         return (
-          props.containerStyle?.paddingBottom || props.containerStyle.padding
+          props.containerStyle?.paddingBottom || props.containerStyle.padding || 0
         );
       }
       if (!props.containerStyle && props?.useBottomSafeAreaPadding) {


### PR DESCRIPTION
If the containerStyle is defined but doesnt have a paddingBottom or a padding, the function returns undefined crashing the app