### PR TITLE
ref.hide fix: allow 'data' to be passed through to onClose

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -686,7 +686,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
           }, 1);
         },
         hide: (data: any) => {
-          hideSheet(data);
+          hideSheet(undefined, data);
         },
         setModalVisible: (_visible?: boolean) => {
           if (_visible) {


### PR DESCRIPTION
This makes `hide` on the ref behave as described in the documentation.

`ref.current?.hide({ confirmed: true });` will now successfully pass `{ confirmed: true }` as the data param, accessible from the `onClose` callback.

Useful for when you only have one sheet and you want to determine whether the customer has dismissed the popover or it has been force closed.