### PR TITLE
Docs: fix type on `initialSnapIndex`

### DIFF
--- a/docs/pages/reference/actionsheet.mdx
+++ b/docs/pages/reference/actionsheet.mdx
@@ -104,9 +104,9 @@ Default: `[100]`
 
 When you have set the `snapPoints` prop. You can use this prop to set the inital snap point for the sheet. For example if i have snap points set to `[30,60,100]` then setting this prop to `1` would mean the action sheet will snap to 60% on becoming visible.
 
-| Type       | Required |
-| ---------- | -------- |
-| `number[]` | no       |
+| Type     | Required |
+| -------- | -------- |
+| `number` | no       |
 
 Default: `0`
 


### PR DESCRIPTION
The `ActionSheet` prop `initialSnapIndex` is incorrectly typed in the docs.