### PR TITLE
Make snap behavior more flexible. Update routing documentation.

### DIFF
--- a/docs/pages/guides/sheetrouter.mdx
+++ b/docs/pages/guides/sheetrouter.mdx
@@ -10,7 +10,7 @@ Router works like any navigation router in your app.
 import ActionSheet, {
   Route,
   RouteScreenProps,
-  useRouter,
+  useSheetRouter,
   useSheetRouteParams,
 } from 'react-native-actions-sheet';
 
@@ -28,7 +28,7 @@ const RouteA = ({router}: RouteScreenProps) => {
 };
 
 const RouteB = () => {
-  const router = useRouter();
+  const router = useSheetRouter();
   const params = useSheetRouteParams();
 
   return (

--- a/docs/pages/reference/meta.json
+++ b/docs/pages/reference/meta.json
@@ -8,7 +8,7 @@
   "registersheet": "registerSheet",
   "showoptions": "ShowOptions",
   "hideoptions": "HideOptions",
-  "userouter": "useRouter",
+  "usesheetrouter": "useSheetRouter",
   "usesheetrouteparams": "useSheetRouteParams",
   "usesheetidcontext": "useSheetIDContext",
   "useprovidercontext": "useProviderContext",

--- a/docs/pages/reference/usesheetrouter.mdx
+++ b/docs/pages/reference/usesheetrouter.mdx
@@ -1,4 +1,4 @@
-# useRouter
+# useSheetRouter
 
 A hook that helps you navigate between routes inside the sheet.
 

--- a/src/hooks/use-router.ts
+++ b/src/hooks/use-router.ts
@@ -89,8 +89,8 @@ export const useRouter = ({
   );
 
   const navigate = useCallback(
-    (name: string, params?: any, snap?: number) => {
-      animate(snap || 20, 0);
+    (name: string, params?: any, snap: number = 20) => {
+      animate(snap, 0);
       setTimeout(() => {
         setStack(state => {
           const next = routes?.find(route => route.name === name);
@@ -132,9 +132,9 @@ export const useRouter = ({
     }).start();
   };
 
-  const goBack = (name?: string, snap?: number) => {
-    getRef?.().snapToRelativeOffset(snap || -10);
-    animate(snap || -10, 0);
+  const goBack = (name?: string, snap: number = -10) => {
+    getRef?.().snapToRelativeOffset(snap);
+    animate(snap, 0);
     setTimeout(() => {
       setStack(state => {
         const next = routes?.find(route => route.name === name);


### PR DESCRIPTION
## Respect 0 snap if explicitly provided
Currently, there's no way to specify a snap of 0 when navigating, since we revert to the default values by virtue of an `||`. This change allows a snap value of 0 to be preserved if provided by the user.

## Update `useRouter`/`useSheetRouter` documentation
`useSheetRouter` is no longer exported, but the documentation still references it. From the looks of it, this should actually be `useSheetRouter`.