### PR TITLE
Correct vertical position of Actionsheet

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -936,7 +936,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
                   ? getZIndexFromStack(sheetId, currentContext)
                   : 999,
                 width: '100%',
-                height: initialWindowHeight.current,
+                height: '100%',
               },
               pointerEvents: props?.backgroundInteractionEnabled
                 ? 'box-none'


### PR DESCRIPTION
# Issue

This PR solves the issue: [#254](https://github.com/ammarahm-ed/react-native-actions-sheet/issues/254)

# Description

This Pull Request addresses the issue where the ActionSheet component's vertical position is not correctly calculated when the React Native screen is not the same height as the device. 
This occurs, for example, when the app uses Native navigation and the React Native view is shorter than the device height, causing a portion of the content to be shifted and hidden below.

The cause of the issue is that the height of the `<Root />` component is hardcoded with the device height here
https://github.com/ammarahm-ed/react-native-actions-sheet/blob/93cf9fc943cf9e30cbbb7d4b15a687d1f3fc040c/src/index.tsx#L939
This is not always the case since the React view can take a different height than the device's height.

To fix this issue, the `index.tsx` has been modified to replace the `initialWindowHeight.current` with `100%` as the height value for the `<Root />` component. This change allows the ActionSheet component to be correctly positioned regardless of the height of the React Native view.

## Testing

I have tested the changes on various devices with different screen heights and confirmed that the ActionSheet component is correctly positioned every time.

## Video

https://user-images.githubusercontent.com/5271876/232089881-34cf187b-a816-4657-87f6-0b42762dde16.mov



