### PR TITLE
Adds `onTouchBackdrop` to pass up the touch event on the backdrop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import {
   BackHandler,
   Dimensions,
   Easing,
+  GestureResponderEvent,
   LayoutChangeEvent,
   LayoutRectangle,
   Modal,
@@ -101,6 +102,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
       overlayColor = 'black',
       closable = true,
       closeOnTouchBackdrop = true,
+      onTouchBackdrop,
       drawUnderStatusBar = false,
       gestureEnabled = false,
       isModal = true,
@@ -702,7 +704,8 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
       ],
     );
 
-    const onTouch = () => {
+    const onTouch = (event: GestureResponderEvent) => {
+      onTouchBackdrop?.(event);
       if (enableRouterBackNavigation && router.canGoBack()) {
         router.goBack();
         return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,11 @@
 import {Route} from './hooks/use-router';
 import React from 'react';
-import {Animated, TouchableOpacityProps, ViewStyle} from 'react-native';
+import {
+  Animated,
+  GestureResponderEvent,
+  TouchableOpacityProps,
+  ViewStyle,
+} from 'react-native';
 
 export type ActionSheetProps = {
   children?: React.ReactNode;
@@ -132,6 +137,13 @@ export type ActionSheetProps = {
    * Default: `true`
    */
   closeOnTouchBackdrop?: boolean;
+
+  /**
+   * Callback when user touches the backdrop. Includes the GestureResponderEvent.
+   *
+   * Default: undefined
+   */
+  onTouchBackdrop?: (event: GestureResponderEvent) => void;
 
   /**
    * Render a component over the ActionSheet. Useful for rendering


### PR DESCRIPTION
Sorry but I was not able to find any templates for PR's on the docs/repo.

In an app we are developing at the company I work for, we need access to the GestureResponderEvent of the backdrop to know if we should change the focus to a underlying input, thus the need of the callback. I imagined it may be someone else's problem, so here is the solution that has been working for us and adds no side/unknown effects to the codebase.