### PR TITLE
fix: Bottom Space Problem on all devices

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -729,7 +729,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
 
         deviceContainerRef.current?.setNativeProps({
           style: {
-            height: Dimensions.get('screen').height - safeMarginFromTop,
+            height: Dimensions.get('screen').height,
           },
         });
 


### PR DESCRIPTION
Fixes the Issue of a sometimes appearing Bottom Space at the ActionSheet.
In this Image you see a big green space on the bottom of the Actionsheet, this appears sometimes on Android and Ios like this Issue told us: [https://github.com/ammarahm-ed/react-native-actions-sheet/issues/222](url)

By removing the `- safeMarginFromTop` it calculates the Actionsheet height correctly and the problem should be solved.

I tested it using version 0.8.29 on Android and Ios, on both Devices it was fixed.

> "react-native-actions-sheet": "^0.8.29",

![237386105-560f8c94-f2fc-46b0-8682-7fe616cdd4b7](https://github.com/ammarahm-ed/react-native-actions-sheet/assets/101802060/6f0d872a-ad77-42fc-9686-ffa639593feb)
