### PR TITLE
Docs: Add isModal={false} requirement to the example for bg interaction

### DIFF
--- a/docs/pages/guides/background.mdx
+++ b/docs/pages/guides/background.mdx
@@ -3,13 +3,13 @@
 One of the main reasons why the library has gone under a complete rewrite is Background interaction. When background interaction is enabled, the ActionSheet uses a regular `View` instead of a `Modal` to make it work. The remaining interaction is exactly the same.
 
 ```tsx
-<ActionSheet backgroundInteractionEnabled={true} />
+<ActionSheet backgroundInteractionEnabled={true} isModal={false} />
 ```
 
 And that's it. Now you can interact the the background. This can be helpful is building Uber, Google Maps like UI where a ActionSheet is always open at the bottom. If you do not want the ActionSheet to close ever, you can use the `closable` prop.
 
 ```tsx
-<ActionSheet closable={false} backgroundInteractionEnabled={true} />
+<ActionSheet closable={false} backgroundInteractionEnabled={true} isModal={false} />
 ```
 
 Now the ActionSheet can't be closed even with gestures.


### PR DESCRIPTION
`backgroundInteractionEnabled` is not enough on its own to allow the background interaction as it is right now. 

I am not sure whether this should actually be fixed in the code so that `isModal` is modified internally when `backgroundInteractionEnabled` is set to `true`. 

But it took me some time to realize that `isModal` prop was required to be set to `false` for the feature to work so I wanted to contribute this small change so that it is clearer for anyone else that comes into the docs seeking how to enable this.