### PR TITLE
FIX :  Invariant Violation: You can define one of bounciness/speed, tension/friction, or stiffness/damping/mass, but not more than one, js engine: hermes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -259,13 +259,24 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
             : 0;
 
         notifyOffsetChange(correctedValue as number);
-        Animated.spring(animations.translateY, {
-          toValue: initialValue.current,
-          useNativeDriver: true,
-          friction: 8,
-          ...config,
-          velocity: typeof velocity !== 'number' ? undefined : velocity,
-        }).start();
+
+        if (!config) {
+          Animated.spring(animations.translateY, {
+            toValue: initialValue.current,
+            useNativeDriver: true,
+            friction: 8,
+            ...config,
+            velocity: typeof velocity !== 'number' ? undefined : velocity,
+          }).start();
+        }else {
+          Animated.spring(animations.translateY, {
+            toValue: initialValue.current,
+            useNativeDriver: true,
+            ...config,
+            velocity: typeof velocity !== 'number' ? undefined : velocity,
+          }).start();
+        }
+      
         notifySnapIndexChanged();
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Resolved issue "Invariant Violation: You can define one of bounciness/speed, tension/friction, or stiffness/damping/mass, but not more than one" for JavaScript engine Hermes.

Implemented fix by ensuring that only one set of physical properties (bounciness/speed, tension/friction, or stiffness/damping/mass) can be defined at a time. This prevents conflicts and maintains consistency in the behavior of the code.

Contributing to the repository with the resolution of this issue.
