### PR TITLE
docs: fix pkg name

### DIFF
--- a/docs/pages/guides/migrate.mdx
+++ b/docs/pages/guides/migrate.mdx
@@ -6,10 +6,10 @@ v0.9.0 does not include any huge breaking changes to the API however there are s
 
 ### Dependencies
 
-The library now depends on `react-native-gesture-handlers` library which is usually already installed in almost every React Native project.
+The library now depends on `react-native-gesture-handler` library which is usually already installed in almost every React Native project.
 
 ```
-npm install react-native-gesture-handlers
+npm install react-native-gesture-handler
 ```
 
 ### `Registering sheets`

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -1,6 +1,6 @@
 # Installation
 
-Install the ActionSheet with `yarn` or `npm`. You will also need to install `react-native-gesture-handlers` if you haven't already.
+Install the ActionSheet with `yarn` or `npm`. You will also need to install `react-native-gesture-handler` if you haven't already.
 
 ```fish
 npm install react-native-actions-sheet react-native-gesture-handler --save

--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -3,7 +3,7 @@
 export default {
   projectLink: 'https://github.com/ammarahm-ed/react-native-actions-sheet', // GitHub link in the navbar
   docsRepositoryBase:
-    'https://github.com/ammarahm-ed/react-native-actions-sheet', // base URL for the docs repository
+    'https://github.com/ammarahm-ed/react-native-actions-sheet/tree/master/docs/pages', // base URL for the docs repository
   nextLinks: true,
   prevLinks: true,
   search: true,


### PR DESCRIPTION
Hi

- Fixes rngh pkg name
- Fixes the `edit this page on gh` link to point to the correct page on github