### PR TITLE
ref can be null in web

### DIFF
--- a/src/hooks/use-scroll-handlers.ts
+++ b/src/hooks/use-scroll-handlers.ts
@@ -120,6 +120,7 @@ export function useScrollHandlers<T>(options?: DraggableNodeOptions) {
     timer.current = setTimeout(() => {
       const ref = resolveScrollRef(nodeRef);
       if (Platform.OS == 'web') {
+        if (!ref) return;
         const rect = (ref as HTMLDivElement).getBoundingClientRect();
         (ref as HTMLDivElement).style.overflow = "auto";
         onMeasure(rect.x, rect.y, rect.width, rect.height, rect.left, rect.top);


### PR DESCRIPTION
On my project, ref is null before not null, so getBoundingClientRect throw error