### PR TITLE
docs: fix docsRepositoryBase

### DIFF
--- a/docs/theme.config.js
+++ b/docs/theme.config.js
@@ -3,7 +3,7 @@
 export default {
   projectLink: 'https://github.com/ammarahm-ed/react-native-actions-sheet', // GitHub link in the navbar
   docsRepositoryBase:
-    'https://github.com/ammarahm-ed/react-native-actions-sheet', // base URL for the docs repository
+    'https://github.com/ammarahm-ed/react-native-actions-sheet/tree/master/docs', // base URL for the docs repository
   nextLinks: true,
   prevLinks: true,
   search: true,


### PR DESCRIPTION
This PR fixes the "Edit this page on GitHub" link

See: https://nextra-v2-oe0zrpzjp-shud.vercel.app/docs/docs-theme/theme-configuration#specify-a-path