### PR TITLE
Add maxWidth property to containerStyle for improved layout flexibility

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1310,7 +1310,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
                               borderRadius:
                                 containerStyle?.borderRadius || undefined,
                               width: containerStyle?.width || '100%',
-                              maxWidth: containerStyle?.maxWidth || undefined,
+                              maxWidth: containerStyle?.maxWidth,
                               ...(!disableElevation
                                 ? getElevation(
                                     typeof elevation === 'number'


### PR DESCRIPTION
On web passing maxWith does noting, I would like to have an option to customize the width of the modal on web so that it doesnt take full space as it looks bizarre 😅 

Before:

<img width="2250" height="318" alt="CleanShot 2025-12-14 at 12 05 58" src="https://github.com/user-attachments/assets/d4d53d9f-8029-4fd9-ab8c-55211850c473" />


After (I passed max-width: 600):

<img width="834" height="477" alt="CleanShot 2025-12-14 at 11 58 02" src="https://github.com/user-attachments/assets/5ce0555c-1a3b-4954-becd-c5cfd5d740de" />
