### PR TITLE
[fix] Fix action sheet opacity for iOS Liquid Glass

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -183,8 +183,13 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
       },
     });
 
+    // NOTE: Opacity of 0 breaks Liquid Glass views on iOS, so we set it to 0.02 to workaround this bug.
+    // See https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value
+    // (more context at https://github.com/expo/expo/issues/41024).
+    const lowestActionSheetOpacity = Platform.OS === "ios" ? 0.02 : 0;
+    
     const opacity = useSharedValue(0);
-    const actionSheetOpacity = useSharedValue(0);
+    const actionSheetOpacity = useSharedValue(lowestActionSheetOpacity);
     const translateY = useSharedValue(Dimensions.get('window').height * 2);
     const underlayTranslateY = useSharedValue(130);
     const routeOpacity = useSharedValue(0);
@@ -241,7 +246,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
           accessibilityInfo.current.prefersCrossFadeTransitions &&
           !gestureEnd
         ) {
-          actionSheetOpacity.value = 0;
+          actionSheetOpacity.value = lowestActionSheetOpacity;
           translateY.value = initial;
           actionSheetOpacity.value = withTiming(1, {
             duration: 150,
@@ -281,7 +286,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
           !gestureEnd
         ) {
           actionSheetOpacity.value = withTiming(
-            0,
+            lowestActionSheetOpacity,
             {
               duration: 200,
               easing: Easing.in(Easing.ease),
@@ -544,7 +549,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
             currentSnapIndex.current = initialSnapIndex;
             closing.current = false;
             initialValue.current = -1;
-            actionSheetOpacity.value = 0;
+            actionSheetOpacity.value = lowestActionSheetOpacity;
             translateY.value = Dimensions.get('window').height * 2;
             keyboard.reset();
           } else {


### PR DESCRIPTION
## Description

This sets a lower bound for the action sheet opacity to 0.02 on iOS, to work around Liquid Glass limitation on iOS where a too low alpha makes the Liquid Glass background disapear entirely.

I've tested with values lower than `0.02`, but these also seem to break Liquid Glass (e.g. `0.01` will not work). I'm currently using these changes here locally and everything seems to be working nicely.

Note that this is a small change to the default value of the opacity on iOS, but I think it's worth not putting behind a prop (or at least making it the default) to avoid people getting a surprising behavior when trying to use Liquid Glass views, which I would assume would only start happening more - not everyone will be lucky to find out that opacity from parent views (even when not active) can break the Liquid Glass views 😅 

More info
- Official docs from Apple https://developer.apple.com/documentation/uikit/uivisualeffectview#Set-the-correct-alpha-value
- More context https://github.com/expo/expo/issues/41024

# Screenshots

| Without this patch, the Liquid Glass effect will disappear entirely | With opacity 0.02 it now shows up |
|--------|--------|
| <img width="465" height="156" alt="Screenshot 2026-02-01 at 13 32 29" src="https://github.com/user-attachments/assets/a2aa10ae-1c4b-47e8-a673-46e0fd7638d6" /> | <img width="464" height="164" alt="Screenshot 2026-02-01 at 13 32 36" src="https://github.com/user-attachments/assets/e1974743-c266-4d4c-bf25-33f5a2b03fef" /> | 

The above is using [Glass Effect from Expo](https://docs.expo.dev/versions/v55.0.0/sdk/glass-effect/), but from the linked issue independent implementations also run into the opacity issue, e.g. https://github.com/callstack/liquid-glass (https://github.com/callstack/liquid-glass/issues/27#issuecomment-3694921766).
