### PR TITLE
feat: add animated position property

### DIFF
--- a/app/examples.tsx
+++ b/app/examples.tsx
@@ -63,6 +63,12 @@ const MainScreen = () => {
       },
     },
     {
+      title: "Animated Position",
+      onOpen: () => {
+        SheetManager.show("animated-position")
+      },
+    },
+    {
       title: 'I can snap!',
       onOpen: () => {
         SheetManager.show('snap-me');

--- a/app/examples.tsx
+++ b/app/examples.tsx
@@ -28,10 +28,10 @@ const MainScreen = () => {
         actionSheetRef.current?.show();
       },
     },
-     {
+    {
       title: 'Custom Background',
       onOpen: () => {
-          SheetManager.show('custom-background');
+        SheetManager.show('custom-background');
       },
     },
     {
@@ -63,9 +63,9 @@ const MainScreen = () => {
       },
     },
     {
-      title: "Animated Position",
+      title: 'Animated Position',
       onOpen: () => {
-        SheetManager.show("animated-position")
+        SheetManager.show('animated-position');
       },
     },
     {
@@ -107,10 +107,10 @@ const MainScreen = () => {
             payload: {
               candy: candyNames[Math.floor(Math.random() * candyNames.length)],
             },
-            shouldUpdate: async (sheet) => {
+            shouldUpdate: async sheet => {
               console.log(sheet.id, sheet.context);
               return true;
-            }
+            },
           });
         }, 3000);
       },

--- a/app/examples/animated-position.tsx
+++ b/app/examples/animated-position.tsx
@@ -11,7 +11,7 @@ function AnimatedPositionSheet() {
 
   const fabPositionStyle = useAnimatedStyle(() => {
     return {
-      top: animatedPosition.value - 80
+      top: animatedPosition.value - 80,
     };
   });
 
@@ -51,8 +51,7 @@ function AnimatedPositionSheet() {
         snapPoints={[40, 100]}
         initialSnapIndex={0}
         animatedPosition={animatedPosition}
-        containerStyle=
-        {{
+        containerStyle={{
           height: '100%',
         }}>
         <View

--- a/app/examples/animated-position.tsx
+++ b/app/examples/animated-position.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import {Text, View, TouchableOpacity} from 'react-native';
+import ActionSheet from 'react-native-actions-sheet';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+function AnimatedPositionSheet() {
+  const animatedPosition = useSharedValue(0);
+
+  const fabPositionStyle = useAnimatedStyle(() => {
+    return {
+      top: animatedPosition.value - 80
+    };
+  });
+
+  return (
+    <>
+      <Animated.View
+        style={[
+          {
+            position: 'absolute',
+            right: 16,
+            elevation: 24,
+          },
+          fabPositionStyle,
+        ]}>
+        <TouchableOpacity
+          style={{
+            width: 64,
+            height: 64,
+            borderRadius: 9999,
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'white',
+            shadowOffset: {
+              width: 4.5,
+              height: 3,
+            },
+            shadowOpacity: 0.3,
+            shadowRadius: 15,
+            elevation: 24,
+          }}>
+          <Text style={{fontSize: 32}}>B</Text>
+        </TouchableOpacity>
+      </Animated.View>
+      <ActionSheet
+        gestureEnabled
+        backgroundInteractionEnabled
+        snapPoints={[40, 100]}
+        initialSnapIndex={0}
+        animatedPosition={animatedPosition}
+        containerStyle=
+        {{
+          height: '100%',
+        }}>
+        <View
+          style={{
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingInline: 36,
+          }}>
+          <Text
+            style={{
+              color: 'black',
+              fontSize: 30,
+              textAlign: 'center',
+            }}>
+            I render a FAB based on the animated position property
+          </Text>
+        </View>
+      </ActionSheet>
+    </>
+  );
+}
+
+export default AnimatedPositionSheet;

--- a/app/sheets.tsx
+++ b/app/sheets.tsx
@@ -23,6 +23,7 @@ import ScrollViewSheet from './examples/scrollview';
 import ResizeSheet from './examples/scrollview-resize';
 import SnapMe from './examples/snap-me';
 import { CustomBackground } from './examples/custom-background';
+import AnimatedPositionSheet from './examples/animated-position';
 
 /**
  * We extend some of the types here to give us great intellisense
@@ -65,7 +66,8 @@ declare module 'react-native-actions-sheet' {
     }>;
     'legend-list': SheetDefinition;
     'custom-scroll-handlers': SheetDefinition;
-    "custom-background": SheetDefinition
+    "custom-background": SheetDefinition;
+    'animated-position': SheetDefinition;
   }
 }
 
@@ -89,7 +91,8 @@ const sheets: SheetRegisterProps['sheets'] = {
   'legend-list': LegendListExample,
   'custom-scroll-handlers': CustomScrollHandlers,
   "hello_two": Hello_Two,
-  "custom-background": CustomBackground
+  "custom-background": CustomBackground,
+  'animated-position': AnimatedPositionSheet
 };
 
 export const AppSheets = () => {

--- a/package.json
+++ b/package.json
@@ -84,8 +84,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
     "docs": "typedoc --plugin typedoc-plugin-markdown --out docs ./index.tsx",
-    "watch": "yarn tsc --watch",
-    "prepare": "npm run build"
+    "watch": "yarn tsc --watch"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc",
     "docs": "typedoc --plugin typedoc-plugin-markdown --out docs ./index.tsx",
-    "watch": "yarn tsc --watch"
+    "watch": "yarn tsc --watch",
+    "prepare": "npm run build"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
   "dependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,6 +101,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
       onBeforeShow,
       enableRouterBackNavigation,
       onBeforeClose,
+      animatedPosition,
       enableGesturesInScrollView = true,
       disableDragBeyondMinimumSnapPoint,
       useBottomSafeAreaPadding = true,
@@ -185,7 +186,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
 
     const opacity = useSharedValue(0);
     const actionSheetOpacity = useSharedValue(0);
-    const translateY = useSharedValue(Dimensions.get('window').height * 2);
+    const internalTranslateY = useSharedValue(Dimensions.get('window').height * 2);
     const underlayTranslateY = useSharedValue(130);
     const routeOpacity = useSharedValue(0);
     const router = useRouter({
@@ -210,6 +211,8 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
     const notifyOffsetChange = (value: number) => {
       internalEventManager.publish('onoffsetchange', value);
     };
+
+    const translateY = animatedPosition ?? internalTranslateY;
 
     const notifySnapIndexChanged = React.useCallback(() => {
       if (prevSnapIndex.current !== currentSnapIndex.current) {
@@ -1428,9 +1431,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
                       {ExtraOverlayComponent}
                       {props.withNestedSheetProvider}
                       {sheetId ? (
-                        <SheetProvider
-                          context={providerId.current}
-                        />
+                        <SheetProvider context={providerId.current} />
                       ) : null}
                     </>
                   </Animated.View>

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ import {
   StyleProp,
   ViewStyle,
 } from 'react-native';
-import {WithSpringConfig} from 'react-native-reanimated';
+import {SharedValue, WithSpringConfig} from 'react-native-reanimated';
 import EventManager from './eventmanager';
 import {Route} from './hooks/use-router';
 
@@ -424,6 +424,12 @@ export type ActionSheetProps<SheetId extends keyof Sheets = never> = {
    * sheet to go beyond minimum snap point position with drag.
    */
   disableDragBeyondMinimumSnapPoint?: boolean;
+
+  /**
+   * Animated value to be used as a callback for the position node internally.
+   * Use this for pixel-perfect animations synchronized with the sheet.
+   */
+  animatedPosition?: SharedValue<number>;
 
   /**
    * Called when the ActionSheet is closing based on some user actions:


### PR DESCRIPTION
## Add `animatedPosition` prop

### Summary

- Adds a new `animatedPosition` prop that exposes the sheet's internal `translateY` shared value, allowing consumers to drive pixel-perfect animations synchronized with the sheet's position
- When provided, the sheet uses the caller's `SharedValue<number>` directly instead of creating its own internal one
- Adds an example demonstrating a floating action button (FAB) that tracks the sheet position

### Changes

- **`src/types.ts`**: Added `animatedPosition?: SharedValue<number>` prop definition
- **`src/index.tsx`**: Renamed internal `translateY` to `internalTranslateY` and uses `animatedPosition ?? internalTranslateY` so the external shared value is written to when the sheet moves
- **`app/examples/animated-position.tsx`**: New example showing a FAB that stays anchored above the sheet as it snaps between positions
- **`app/sheets.tsx`** / **`app/examples.tsx`**: Registered and wired up the new example

### Closes #478 

### Screenshots

https://github.com/user-attachments/assets/997f2219-21b9-4a5a-81f6-86f323aa2e7d

### Test plan

- [ ] Open the "Animated Position" example in the example app
- [ ] Verify the FAB moves in sync with the sheet as it snaps between 40% and 100%
- [ ] Verify dragging the sheet updates the FAB position in real time
- [ ] Verify existing sheets without `animatedPosition` still work (no regression)