### PR TITLE
feat(action-sheet): add initialVisible prop for immediate rendering

### DIFF
--- a/app/examples.tsx
+++ b/app/examples.tsx
@@ -188,6 +188,7 @@ const MainScreen = () => {
     <>
       <SafeAreaView style={[styles.safeareview, {}]}>
         <ActionSheet
+          initialVisible
           ref={actionSheetRef}
           gestureEnabled
           containerStyle={{

--- a/src/hooks/use-sheet-manager.ts
+++ b/src/hooks/use-sheet-manager.ts
@@ -8,13 +8,15 @@ const useSheetManager = ({
   onHide,
   onBeforeShow,
   onContextUpdate,
+  initialVisible = false,
 }: {
   id?: string;
   onHide: (data?: any) => void;
   onBeforeShow?: (data?: any, snapIndex?: number) => void;
   onContextUpdate: () => void;
+  initialVisible?: boolean;
 }) => {
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(initialVisible);
   const currentContext = useProviderContext();
   const visibleRef = useRef({
     value: visible,

--- a/src/types.ts
+++ b/src/types.ts
@@ -407,6 +407,13 @@ export type ActionSheetProps<SheetId extends keyof Sheets = never> = {
    */
   initialRoute?: keyof Sheets[SheetId]['routes'] | (string & {});
   /**
+   * Set the ActionSheet to be visible on initial render. When true, the sheet
+   * appears immediately without the opening animation.
+   *
+   * Default: `false`
+   */
+  initialVisible?: boolean;
+  /**
    * Enable back navigation for router when pressing hardware back button or
    * touching the back drop. Remember that swiping down the sheet will still close
    * the sheet regardless of the route in stack.


### PR DESCRIPTION
## Add `initialVisible` prop for immediate rendering

### Summary

- Adds a new `initialVisible` prop to `ActionSheetProps` that allows the sheet to be visible immediately on initial render, without the opening animation.
- When `initialVisible` is `true`, the sheet sets its opacity and position directly to their open-state values instead of running the spring animation, avoiding any flicker or delay.
- Passes `initialVisible` through to `useSheetManager` so the internal `visible` state is initialized to `true`.

This eliminates the need for workarounds like calling `ref.show()` inside a `setTimeout` after mount.

### Closes #404

### Test plan

- [ ] Verify a sheet with `initialVisible` renders fully open on mount with no animation flicker
- [ ] Verify a sheet without `initialVisible` still animates open as before (no regression)
- [ ] Verify the initially-visible sheet can be closed and re-opened normally after the initial render
- [ ] Test on both iOS and Android