### PR TITLE
fix: stop reversing in place in SheetManager.get

### DIFF
--- a/src/sheetmanager.tsx
+++ b/src/sheetmanager.tsx
@@ -319,7 +319,7 @@ class _SheetManager {
     context?: string,
   ): RefObject<ActionSheetRef<SheetId>> => {
     if (!context) {
-      for (let _id of renderedSheetIds.reverse()) {
+      for (let _id of renderedSheetIds.slice().reverse()) {
         if (_id.includes(`${id}:`)) {
           context = _id.split(':')[1];
         }


### PR DESCRIPTION
### Issue
I'm running into a bug with nested sheets where i'm having sheets disappear from `renderedSheetIds`. Example flow:
1) Open parent sheet A
2) Open child sheet B
3) Close child B
4) Open another child C
5) Try to hide/close both child sheet C and parent sheet A. Only sheet C closes, and parent sheet A stays open.

When I check `getActiveSheets` after closing child sheet (B), it doesn't contain the parent sheet (A) anymore.

### Root cause
When calling `SheetManager.get(sheetId)` without a context, the library iterates through `renderedSheetIds` using `renderedSheetIds.reverse()`. This mutates the array in place, which messes up the ordering of `renderedSheetIds`.

Then if we call `SheetManager.remove()` it removes all ids starting from the passed in id to the end of the array. Since we reversed the renderedSheetIds in place, it was probably removing the sheets that were still open when we close a sheet, due to the array order.

### Fix

In `SheetManager.get()` instead of iterating `renderedSheetIds.reverse()` in place, iterate over a copy: `renderedSheetIds.slice().reverse()`