### PR TITLE
fix: wrap onEnd gesture handler to prevent worklets bundle-mode crash (deltaYOnGestureStart)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -994,7 +994,7 @@ export default forwardRef<ActionSheetRef, ActionSheetProps>(
             .runOnJS(true)
             .activeOffsetY([-5, 5])
             .failOffsetX([-5, 5])
-            .onEnd(onEnd);
+            .onEnd(() => onEnd());
     }, [gestureEnabled]);
 
     const onTouch = (event: GestureResponderEvent) => {


### PR DESCRIPTION
## Summary

With `react-native-reanimated` v4 / `react-native-worklets` in bundle mode, dragging a sheet to dismiss crashes at the end of the pan gesture:

```
ReferenceError: Property 'deltaYOnGestureStart' doesn't exist
  at react-native-worklets/.worklets/<hash>.js (reactNativeActionsSheet_indexJs...)
```

Repro versions: react-native-actions-sheet 10.1.2, react-native-reanimated 4.5.0, react-native-worklets 0.10.0 (Babel plugin with `bundleMode: true`, `strictGlobal: true`).

## Root cause

In bundle mode the worklets Babel plugin extracts each gesture callback into its own worklet file and serializes its closure. The pan gesture passes `onEnd` directly:

```ts
.onChange(event => onChange(event.absoluteX, event.absoluteY, event.translationY)) // wrapped
.runOnJS(true)
.onEnd(onEnd) // passed directly
```

So the extracted worklet *is* `onEnd`, whose first statement writes a mutable closure primitive:

```ts
const onEnd = () => {
  if (!gestureEnabled) return;
  deltaYOnGestureStart = 0; // write to a closure `let` shared with onChange -> crashes in the worklet
  ...
};
```

`onChange` does not crash because it is passed wrapped in an arrow function: the extracted worklet is a thin shim that just calls `onChange` (captured by reference), and with `.runOnJS(true)` that call runs on the JS thread where the closure is intact. `onEnd` lacks this indirection.

## Fix

Wrap `onEnd` the same way `onChange` already is, so the extracted worklet is a thin shim and the closure writes happen in the real JS function:

```ts
.onEnd(() => onEnd());
```

One line, no behavior change: `onEnd` still runs on the JS thread via `.runOnJS(true)`, identical to how `onChange` is handled.

## Test plan

- Build a sheet with `gestureEnabled` and a scrollable body, on an app using reanimated 4 / worklets bundle mode.
- Drag the sheet down and release: before this change it crashes with the ReferenceError above, after it the sheet snaps/closes normally.
- Verify scroll inside the sheet, backdrop tap, and Android back button still work.
