### PR TITLE
fix: export CloseRequestType from the package root

### DIFF
--- a/docs/pages/reference/actionsheet.mdx
+++ b/docs/pages/reference/actionsheet.mdx
@@ -488,3 +488,11 @@ Return `false` to cancel closing the ActionSheet.
 | Type                                  | Required |
 | ------------------------------------- | -------- |
 | `(type: CloseRequestType) => boolean` | no       |
+
+`CloseRequestType` is exported from the package root:
+
+```js
+import {CloseRequestType} from 'react-native-actions-sheet';
+
+// CloseRequestType.SWIPE | CloseRequestType.BACK_PRESS | CloseRequestType.TOUCH_BACKDROP
+```

--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,7 @@ export {
   SheetDefinition,
   Sheets,
   ActionSheetRef,
+  CloseRequestType,
 } from './src/types';
 export {useScrollHandlers} from './src/hooks/use-scroll-handlers';
 export {


### PR DESCRIPTION
### Problem

`onRequestClose?: (type: CloseRequestType) => boolean` is public API, and [the docs reference names the enum in its signature](https://github.com/ammarahm-ed/react-native-actions-sheet/blob/master/docs/pages/reference/actionsheet.mdx#onrequestclose), but `CloseRequestType` is declared in `src/types` and left out of the root export list:

```ts
import ActionSheet, {CloseRequestType} from 'react-native-actions-sheet';
// TS2305: Module '"react-native-actions-sheet"' has no exported member 'CloseRequestType'.
```

Consumers have to type the handler as `(type: number) => boolean` and hard-code the three values read out of `dist/src/types.d.ts`.

### Fix

Adds `CloseRequestType` to the existing `./src/types` re-export in `index.ts`.

It is an enum, so the value binding matters as well as the type. `tsc` currently drops that entire statement from `dist/index.js` because every member of it is type-only, so the published file has no `./src/types` line at all. With the enum included it survives:

```js
export {};                                     // emitted today
export {CloseRequestType} from './src/types';  // emitted with this change
```

Also adds a note under `onRequestClose` in the docs showing where to import it from. Happy to drop that commit if you'd rather keep this to `index.ts`.
